### PR TITLE
Change import of is_prng_key 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         nox-session: ["tests"]
         include:
           - os: macos-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "numpyro-ext"
 description = "A miscellaneous set of helper functions, custom distributions, and other utilities that I find useful when using NumPyro in my work"
 authors = [{ name = "Dan Foreman-Mackey", email = "foreman.mackey@gmail.com" }]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "Apache License" }
 classifiers = [
     "Operating System :: OS Independent",
@@ -32,7 +32,7 @@ ncx2 = ["tensorflow-probability"]
 write_to = "src/numpyro_ext/version.py"
 
 [tool.black]
-target-version = ["py38", "py39"]
+target-version = ["py39"]
 line-length = 88
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
 ]
 dynamic = ["version"]
-dependencies = ["numpyro>=0.10.1"]
+dependencies = ["numpyro>=0.13.1"]
 
 [project.urls]
 "Homepage" = "https://github.com/dfm/numpyro-ext"

--- a/src/numpyro_ext/distributions.py
+++ b/src/numpyro_ext/distributions.py
@@ -15,7 +15,8 @@ from jax import lax
 from jax.scipy.linalg import cho_factor, cho_solve
 from numpyro.distributions import MixtureGeneral as MixtureGeneral
 from numpyro.distributions import constraints, transforms
-from numpyro.distributions.util import is_prng_key, promote_shapes, validate_sample
+from numpyro.distributions.util import promote_shapes, validate_sample
+from numpyro.util import is_prng_key
 
 from numpyro_ext.linear_op import to_linear_op
 


### PR DESCRIPTION
I'm getting a DeprecationWarning from using `numpyro.distributions.util.is_prng_key()`:

Example:
```bash
python -W "default::DeprecationWarning" -c "from numpyro.distributions.util import is_prng_key; is_prng_key(42)"
```

It looks like it was moved in this PR:
https://github.com/pyro-ppl/numpyro/pull/1642

This would require `numpyro>=0.13.1` https://github.com/pyro-ppl/numpyro/releases/tag/0.13.1 -- do you want me to add some backwards compatibility here? Or add the numpyro version constraint?